### PR TITLE
Reduce database API leaks.

### DIFF
--- a/crates/flashpoint-core/src/lib.rs
+++ b/crates/flashpoint-core/src/lib.rs
@@ -87,9 +87,8 @@ impl FlashpointService {
         .join("services.json"),
     )
     .await?;
-    let db_init_data = flashpoint_database::types::InitData { db_path: db_path };
     Ok(Self {
-      db: flashpoint_database::initialize(db_init_data)?,
+      db: flashpoint_database::initialize(&db_path)?,
       initialized: false,
       base_path: base_path.canonicalize()?.to_str().unwrap().to_string(),
       config,

--- a/crates/flashpoint-core/src/lib.rs
+++ b/crates/flashpoint-core/src/lib.rs
@@ -1,6 +1,6 @@
 use cfg_if::cfg_if;
 use flashpoint_config::types::{Config, Preferences};
-use flashpoint_database::{establish_connection, SqliteConnection};
+use flashpoint_database::types::DbState;
 use std::path::Path;
 use tokio::fs::File;
 
@@ -49,7 +49,7 @@ pub struct FlashpointSignals {
 }
 
 pub struct FlashpointService {
-  pub db: SqliteConnection,
+  pub db: DbState,
   pub initialized: bool,
   pub base_path: String,
   pub config: Config,
@@ -87,9 +87,9 @@ impl FlashpointService {
         .join("services.json"),
     )
     .await?;
-
+    let db_init_data = flashpoint_database::types::InitData { db_path: db_path };
     Ok(Self {
-      db: establish_connection(&db_path)?,
+      db: flashpoint_database::initialize(db_init_data)?,
       initialized: false,
       base_path: base_path.canonicalize()?.to_str().unwrap().to_string(),
       config,

--- a/crates/flashpoint-database/src/game.rs
+++ b/crates/flashpoint-database/src/game.rs
@@ -1,26 +1,24 @@
 use diesel::prelude::*;
 
 use crate::models::{Game, ViewGame};
+use crate::schema::game::dsl::*;
+use crate::types::DbState;
 
-pub fn view_all_games(conn: &mut SqliteConnection) -> Vec<ViewGame> {
-  use crate::schema::game::dsl::*;
+pub fn view_all_games(state: &mut DbState) -> Vec<ViewGame> {
   game
     .select((id, title, developer, publisher, series, platform, tagsStr))
-    .load::<ViewGame>(conn)
+    .load::<ViewGame>(&mut state.conn)
     .expect("Error loading posts")
 }
 
-pub fn find_all_games(conn: &mut SqliteConnection) -> Vec<Game> {
-  use crate::schema::game::dsl::*;
-  game.load::<Game>(conn).expect("Error loading posts")
+pub fn find_all_games(state: &mut DbState) -> Vec<Game> {
+  game
+    .load::<Game>(&mut state.conn)
+    .expect("Error loading posts")
 }
 
-pub fn find_game(
-  conn: &mut SqliteConnection,
-  game_id: String,
-) -> Result<Game, diesel::result::Error> {
-  use crate::schema::game::dsl::*;
-  game.find(game_id).first(conn)
+pub fn find_game(state: &mut DbState, game_id: String) -> Result<Game, diesel::result::Error> {
+  game.find(game_id).first(&mut state.conn)
 }
 
 // find_game_row (?)

--- a/crates/flashpoint-database/src/lib.rs
+++ b/crates/flashpoint-database/src/lib.rs
@@ -5,7 +5,7 @@ pub mod models;
 pub mod schema;
 pub mod tag;
 pub mod types;
-use types::{DbErrors, DbState, InitData};
+use types::{DbErrors, DbState};
 
 fn establish_connection(db_path: &str) -> Result<SqliteConnection, DbErrors> {
   match SqliteConnection::establish(db_path) {
@@ -14,7 +14,7 @@ fn establish_connection(db_path: &str) -> Result<SqliteConnection, DbErrors> {
   }
 }
 
-pub fn initialize(data: InitData) -> Result<DbState, types::DbErrors> {
-  let conn = establish_connection(&data.db_path)?;
+pub fn initialize(db_path: &str) -> Result<DbState, types::DbErrors> {
+  let conn = establish_connection(db_path)?;
   Ok(DbState { conn })
 }

--- a/crates/flashpoint-database/src/lib.rs
+++ b/crates/flashpoint-database/src/lib.rs
@@ -4,8 +4,17 @@ pub mod game;
 pub mod models;
 pub mod schema;
 pub mod tag;
-pub use diesel::sqlite::SqliteConnection;
+pub mod types;
+use types::{DbErrors, DbState, InitData};
 
-pub fn establish_connection(db_path: &str) -> Result<SqliteConnection, diesel::ConnectionError> {
-  SqliteConnection::establish(db_path)
+fn establish_connection(db_path: &str) -> Result<SqliteConnection, DbErrors> {
+  match SqliteConnection::establish(db_path) {
+    Ok(conn) => Ok(conn),
+    Err(e) => Err(DbErrors::Connection(e)),
+  }
+}
+
+pub fn initialize(data: InitData) -> Result<DbState, types::DbErrors> {
+  let conn = establish_connection(&data.db_path)?;
+  Ok(DbState { conn })
 }

--- a/crates/flashpoint-database/src/tag.rs
+++ b/crates/flashpoint-database/src/tag.rs
@@ -1,5 +1,6 @@
 use crate::models::TagCategory;
 use crate::schema::tag_category;
+use crate::types::DbState;
 use diesel::prelude::*;
 use serde::Deserialize;
 
@@ -27,59 +28,60 @@ pub struct InsertableTagCategory {
 
 // find_tag_suggestions
 
-pub fn find_tag_categories(conn: &mut SqliteConnection) -> Vec<TagCategory> {
+pub fn find_tag_categories(state: &mut DbState) -> Vec<TagCategory> {
   use crate::schema::tag_category::dsl::*;
   tag_category
-    .load::<TagCategory>(conn)
+    .load::<TagCategory>(&mut state.conn)
     .expect("Error loading tag categories")
 }
 
 pub fn create_tag_category(
-  conn: &mut SqliteConnection,
+  state: &mut DbState,
   new_category: InsertableTagCategory,
 ) -> Result<TagCategory, diesel::result::Error> {
   diesel::insert_into(tag_category::table)
     .values(&new_category)
-    .execute(conn)?;
+    .execute(&mut state.conn)?;
   // TODO: Broadcast changes?
   // Find and return the newly created category
   tag_category::table
     .filter(tag_category::name.eq(new_category.name))
-    .first(conn)
+    .first(&mut state.conn)
 }
 
 pub fn save_tag_category(
-  conn: &mut SqliteConnection,
+  state: &mut DbState,
   category: InsertableTagCategory,
 ) -> Result<usize, diesel::result::Error> {
   diesel::update(tag_category::table)
     .set(&category)
-    .execute(conn)
+    .execute(&mut state.conn)
 }
 
 pub fn get_tag_category(
-  conn: &mut SqliteConnection,
+  state: &mut DbState,
   category_id: i32,
 ) -> Result<TagCategory, diesel::result::Error> {
   tag_category::table
     .filter(tag_category::id.eq(category_id))
-    .first(conn)
+    .first(&mut state.conn)
 }
 
 pub fn get_tag_category_by_name(
-  conn: &mut SqliteConnection,
+  state: &mut DbState,
   name: String,
 ) -> Result<TagCategory, diesel::result::Error> {
   tag_category::table
     .filter(tag_category::name.eq(name))
-    .first(conn)
+    .first(&mut state.conn)
 }
 
 pub fn delete_tag_category(
-  conn: &mut SqliteConnection,
+  state: &mut DbState,
   category_id: i32,
 ) -> Result<usize, diesel::result::Error> {
-  diesel::delete(tag_category::table.filter(tag_category::id.eq(category_id))).execute(conn)
+  diesel::delete(tag_category::table.filter(tag_category::id.eq(category_id)))
+    .execute(&mut state.conn)
 }
 
 // find_game_tags

--- a/crates/flashpoint-database/src/types.rs
+++ b/crates/flashpoint-database/src/types.rs
@@ -1,0 +1,33 @@
+use diesel::SqliteConnection;
+
+#[derive(Debug)]
+pub enum DbErrors {
+  Connection(diesel::ConnectionError),
+  ReadFailed,
+}
+
+impl std::fmt::Display for DbErrors {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      DbErrors::Connection(e) => {
+        write!(f, "database connection error: {}", e)
+      }
+      DbErrors::ReadFailed => {
+        write!(f, "database read failure")
+      }
+    }
+  }
+}
+
+impl std::error::Error for DbErrors {}
+
+/// The data required for database state initialization.
+#[derive(Debug)]
+pub struct InitData {
+  pub db_path: String,
+}
+
+/// An opaque structure that holds the current database state.
+pub struct DbState {
+  pub(crate) conn: SqliteConnection,
+}

--- a/crates/flashpoint-database/src/types.rs
+++ b/crates/flashpoint-database/src/types.rs
@@ -21,12 +21,6 @@ impl std::fmt::Display for DbErrors {
 
 impl std::error::Error for DbErrors {}
 
-/// The data required for database state initialization.
-#[derive(Debug)]
-pub struct InitData {
-  pub db_path: String,
-}
-
 /// An opaque structure that holds the current database state.
 pub struct DbState {
   pub(crate) conn: SqliteConnection,


### PR DESCRIPTION
If we pass around an opaque DbState instead of a SqliteConnection, we can make arbitrary changes to the information stored in the state object without changing the API.